### PR TITLE
feat: Save email body to external text file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,30 @@ It is designed to be robust and efficient, with features for handling large mail
 
 The application can be configured using the following command-line arguments:
 
-| Argument      | Description                                                               | Required | Default |
-|---------------|---------------------------------------------------------------------------|----------|---------|
-| `-token`      | Access token for the Microsoft Graph API.                                 | **Yes**  |         |
-| `-mailbox`    | The email address of the mailbox to download (e.g., `user@example.com`).  | **Yes**  |         |
-| `-workspace`  | The absolute path to a unique folder for storing downloaded artifacts.    | **Yes**  |         |
-| `-config`     | Path to a JSON configuration file.                                        | No       |         |
-| `-timeout`    | HTTP client timeout in seconds.                                           | No       | `120`   |
-| `-parallel`   | Maximum number of parallel downloads.                                     | No       | `10`    |
-| `-api-rate`   | API calls per second for client-side rate limiting.                       | No       | `5.0`   |
-| `-api-burst`  | API burst capacity for client-side rate limiting.                         | No       | `10`    |
-| `-healthcheck`| Perform a health check on the mailbox and exit.                           | No       | `false` |
-| `-version`    | Display the application version and exit.                                 | No       | `false` |
+| Argument                       | Description                                                                    | Required | Default     |
+|--------------------------------|--------------------------------------------------------------------------------|----------|-------------|
+| `-token-string`                | Provides the JWT token directly as a string.                                   | **One of**   |             |
+| `-token-file`                  | Path to a file containing the JWT token.                                       | **One of**   |             |
+| `-token-env`                   | Reads the JWT token from the `JWT_TOKEN` environment variable.                 | **One of**   |             |
+| `-remove-token-file`           | If using `-token-file`, remove the file after use.                             | No       | `false`     |
+| `-mailbox`                     | The email address of the mailbox to download (e.g., `user@example.com`).       | **Yes**  |             |
+| `-workspace`                   | The absolute path to a unique folder for storing downloaded artifacts.         | **Yes**  |             |
+| `-config`                      | Path to a JSON configuration file.                                             | No       |             |
+| `-processing-mode`             | The processing mode. One of `full`, `incremental`, or `route`.                 | No       | `route`     |
+| `-processed-folder`            | In `route` mode, the folder to move successfully processed emails to.            | No       | `processed` |
+| `-error-folder`                | In `route` mode, the folder to move emails that failed to process.               | No       | `error`     |
+| `-timeout`                     | HTTP client timeout in seconds.                                                | No       | `120`       |
+| `-parallel`                    | Maximum number of parallel downloads.                                          | No       | `10`        |
+| `-max-retries`                 | Maximum number of retries for failed API calls.                                | No       | `5`         |
+| `-initial-backoff-seconds`     | Initial backoff in seconds for retries.                                        | No       | `1`         |
+| `-large-attachment-threshold-mb` | Threshold in MB for large attachments.                                         | No       | `20`        |
+| `-chunk-size-mb`               | Chunk size in MB for large attachment downloads.                               | No       | `4`         |
+| `-api-rate`                    | API calls per second for client-side rate limiting.                            | No       | `5.0`       |
+| `-api-burst`                   | API burst capacity for client-side rate limiting.                              | No       | `10`        |
+| `-dir-perms`                   | Permissions for created directories (e.g., `750`).                             | No       | `755`       |
+| `-file-perms`                  | Permissions for created files (e.g., `640`).                                   | No       | `644`       |
+| `-healthcheck`                 | Perform a health check on the mailbox and exit.                                | No       | `false`     |
+| `-version`                     | Display the application version and exit.                                      | No       | `false`     |
 
 ## Configuration File
 
@@ -42,8 +54,17 @@ For more advanced configuration, you can use a JSON file (e.g., `config.json`) a
 
 ### Example `config.json`
 
+A configuration file can specify any of the command-line arguments. Note that only one token source (`tokenString`, `tokenFile`, or `tokenEnv`) should be specified.
+
 ```json
 {
+  "tokenFile": "/path/to/secure/token.txt",
+  "removeTokenFile": true,
+  "mailboxName": "user@example.com",
+  "workspacePath": "/path/to/your/output",
+  "processingMode": "route",
+  "processedFolder": "Processed-Emails",
+  "errorFolder": "Failed-Emails",
   "httpClientTimeoutSeconds": 180,
   "maxRetries": 7,
   "initialBackoffSeconds": 2,
@@ -51,45 +72,95 @@ For more advanced configuration, you can use a JSON file (e.g., `config.json`) a
   "chunkSizeMB": 8,
   "maxParallelDownloads": 15,
   "apiCallsPerSecond": 3.0,
-  "apiBurst": 6
+  "apiBurst": 6,
+  "dirPerms": 750,
+  "filePerms": 640
 }
 ```
 
 ### Configuration Directives
 
-*   `httpClientTimeoutSeconds`: (Integer) Timeout in seconds for HTTP requests.
-*   `maxRetries`: (Integer) Maximum number of retries for failed API requests.
-*   `initialBackoffSeconds`: (Integer) Initial backoff duration in seconds for the retry mechanism.
-*   `largeAttachmentThresholdMB`: (Integer) Attachments larger than this size (in MB) will be downloaded in chunks.
-*   `chunkSizeMB`: (Integer) The size (in MB) of each chunk for large attachment downloads.
-*   `maxParallelDownloads`: (Integer) The maximum number of messages to process concurrently.
-*   `apiCallsPerSecond`: (Float) The number of API calls allowed per second.
-*   `apiBurst`: (Integer) The burst capacity for the API rate limiter.
+*   `tokenString`: (String) The JWT token as a string.
+*   `tokenFile`: (String) Path to a file containing the JWT token.
+*   `tokenEnv`: (Boolean) If `true`, reads the token from the `JWT_TOKEN` environment variable.
+*   `removeTokenFile`: (Boolean) If `true` and `tokenFile` is used, the token file will be deleted after use. Default: `false`.
+*   `mailboxName`: (String) **Required**. The email address of the mailbox to download.
+*   `workspacePath`: (String) **Required**. The absolute path to a unique folder for storing downloaded artifacts.
+*   `processingMode`: (String) The processing mode. One of `full`, `incremental`, or `route`. Default: `route`.
+*   `processedFolder`: (String) In `route` mode, the folder to move successfully processed emails to. Default: `processed`.
+*   `errorFolder`: (String) In `route` mode, the folder to move emails that failed to process. Default: `error`.
+*   `httpClientTimeoutSeconds`: (Integer) Timeout in seconds for HTTP requests. Default: `120`.
+*   `maxRetries`: (Integer) Maximum number of retries for failed API requests. Default: `5`.
+*   `initialBackoffSeconds`: (Integer) Initial backoff duration in seconds for the retry mechanism. Default: `1`.
+*   `largeAttachmentThresholdMB`: (Integer) Attachments larger than this size (in MB) will be downloaded in chunks. Default: `20`.
+*   `chunkSizeMB`: (Integer) The size (in MB) of each chunk for large attachment downloads. Default: `4`.
+*   `maxParallelDownloads`: (Integer) The maximum number of messages to process concurrently. Default: `10`.
+*   `apiCallsPerSecond`: (Float) The number of API calls allowed per second. Default: `5.0`.
+*   `apiBurst`: (Integer) The burst capacity for the API rate limiter. Default: `10`.
+*   `dirPerms`: (Integer) Permissions for created directories (in octal format). Default: `755`.
+*   `filePerms`: (Integer) Permissions for created files (in octal format). Default: `644`.
+
+## JSON Output
+
+For each email processed, the application creates a JSON file in the workspace directory. The filename is the message ID of the email (e.g., `AAMkAG...=.json`). This file contains detailed information about the processed email.
+
+### Example JSON Output
+
+```json
+{
+  "to": [
+    "recipient1@example.com"
+  ],
+  "from": "sender@example.com",
+  "subject": "Project Update & Attachments",
+  "receivedDate": "2023-10-27T10:30:00Z",
+  "bodyFile": "AAMkAG...=_body.txt",
+  "attachments": [
+    {
+      "name": "Project-Plan.docx",
+      "size": 12345,
+      "downloadUrl": "Project-Plan.docx_AAMkAG...=_Project-Plan.docx"
+    }
+  ],
+  "status": {
+    "state": "success",
+    "details": "Message processed successfully."
+  }
+}
+```
+
+### JSON Field Descriptions
+
+*   `to`: (Array of Strings) A list of recipient email addresses.
+*   `from`: (String) The sender's email address.
+*   `subject`: (String) The subject line of the email.
+*   `receivedDate`: (String) The date and time the email was received, in RFC3339 format.
+*   `bodyFile`: (String) The local filename of the text file containing the cleaned, plain-text version of the email body.
+*   `attachments`: (Array of Objects) A list of objects, where each object represents an attachment.
+    *   `name`: (String) The original filename of the attachment.
+    *   `size`: (Integer) The size of the attachment in bytes.
+    *   `downloadUrl`: (String) The local filename of the downloaded attachment within the workspace. **Note:** This is not a web URL.
+*   `status`: (Object) Contains the final processing status of the email.
+    *   `state`: (String) The final state, either `success` or `error`.
+    *   `details`: (String) A summary of the processing outcome. In case of an error, this will contain details about what went wrong.
 
 ## Examples
 
-### 1. Displaying the Application Version
+### 1. Running with Minimal Required Arguments
 
-To display the version of the application, use the `-version` flag:
+This example runs the application with only the essential arguments, providing the token as a string. All other settings will use their default values (e.g., `processing-mode route`).
 
 ```shell
-./o365mbx -version
+./o365mbx -token-string "YOUR_ACCESS_TOKEN" -mailbox "user@example.com" -workspace "/path/to/your/output"
 ```
 
-### 2. Running with Minimal Required Arguments
+### 2. Running with All Command-Line Arguments
 
-This example runs the application with only the essential arguments:
-
-```shell
-./o365mbx -token "YOUR_ACCESS_TOKEN" -mailbox "user@example.com" -workspace "/path/to/your/output"
-```
-
-### 3. Running with All Command-Line Arguments
-
-This example demonstrates using all available command-line flags to customize behavior:
+This example demonstrates using all available command-line flags to customize behavior, reading the token from a file and removing it after use.
 
 ```shell
-./o365mbx -token "YOUR_ACCESS_TOKEN" \
+./o365mbx -token-file "/path/to/token.txt" \
+          -remove-token-file \
           -mailbox "user@example.com" \
           -workspace "/path/to/your/output" \
           -timeout 300 \
@@ -98,35 +169,85 @@ This example demonstrates using all available command-line flags to customize be
           -api-burst 5
 ```
 
-### 4. Running with a Configuration File
+### 3. Running with a Configuration File
 
-First, create a `config.json` file. Then, run the application pointing to this file:
+You can specify all required arguments in the `config.json` file. If a setting is defined in both the config file and as a command-line flag, the command-line flag will always take precedence.
 
+If all required arguments (`accessToken`, `mailboxName`, `workspacePath`) are in the config file, you only need to provide the `-config` flag:
 ```shell
-./o365mbx -token "YOUR_ACCESS_TOKEN" \
-          -mailbox "user@example.com" \
-          -workspace "/path/to/your/output" \
-          -config "/path/to/your/config.json"
+./o365mbx -config "/path/to/your/config.json"
 ```
 
-**Note on Overrides**: If `maxParallelDownloads` is `15` in `config.json` but you specify `-parallel 5` on the command line, the application will use `5`.
+You can still provide other flags to override specific settings in the file:
+```shell
+# This will use the settings from the config file, but override the number of parallel downloads.
+./o365mbx -config "/path/to/your/config.json" -parallel 5
+```
+
+## Processing Modes
+
+The application has three distinct processing modes, configured via the `-processing-mode` flag or the `processingMode` JSON key.
+
+### `route` (Default)
+
+This is the default mode. In `route` mode, the application will:
+1.  Process all messages currently in the Inbox.
+2.  Move successfully processed emails to the "processed" folder (or the folder specified by `-processed-folder`).
+3.  Move emails that failed to process to the "error" folder (or the folder specified by `-error-folder`).
+
+This mode is ideal for automated, continuous processing, as the Inbox is cleared of processed items after each run.
+
+**Example:**
+```shell
+./o365mbx -token-string "YOUR_TOKEN" \
+          -mailbox "user@example.com" \
+          -workspace "/path/to/output" \
+          -processing-mode route \
+          -processed-folder "Archive-Success" \
+          -error-folder "Archive-Failed"
+```
+
+### `incremental`
+
+In `incremental` mode, the application will:
+1.  Check the `last_run_timestamp.txt` file in the workspace to see when it last ran.
+2.  Process only emails that have arrived *since* that timestamp.
+3.  **Emails are not moved** from the Inbox.
+
+This mode is useful for periodically downloading new emails without altering the state of the mailbox.
+
+**Example:**
+```shell
+./o365mbx -token-string "YOUR_TOKEN" \
+          -mailbox "user@example.com" \
+          -workspace "/path/to/output" \
+          -processing-mode incremental
+```
+
+### `full`
+
+In `full` mode, the application will:
+1.  Process **all** emails in the Inbox, regardless of when it last ran.
+2.  **Emails are not moved** from the Inbox.
+
+This mode is useful for creating a complete, one-time backup of the entire Inbox.
+
+**Example:**
+```shell
+./o365mbx -token-string "YOUR_TOKEN" \
+          -mailbox "user@example.com" \
+          -workspace "/path/to/output" \
+          -processing-mode full
+```
 
 ## Health Check Mode
 
 The health check mode allows you to quickly verify that the application can connect to the specified mailbox and that the access token is valid. It retrieves and displays the total message count in the inbox.
 
-To run a health check, use the `-healthcheck` flag:
+To run a health check, use the `-healthcheck` flag. You must still provide a token source.
 
 ```shell
-./o365mbx -token "YOUR_ACCESS_TOKEN" -mailbox "user@example.com" -healthcheck
-```
-
-## Building from Source
-
-To build the application from source, you need to have Go installed. You can build it using the following command, which also embeds the version number:
-
-```shell
-go build -ldflags "-s -w -X main.version=$(cat version.txt)" -o o365mbx
+./o365mbx -token-env -mailbox "user@example.com" -healthcheck
 ```
 
 ## License

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,0 +1,352 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"o365mbx/apperrors"
+	"o365mbx/config"
+	"o365mbx/emailprocessor"
+	"o365mbx/filehandler"
+	"o365mbx/o365client"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Run handles the main logic for downloading emails and attachments.
+func Run(ctx context.Context, cfg *config.Config, rng *rand.Rand) {
+	// Argument validation specific to download mode
+	if err := validateWorkspacePath(cfg.WorkspacePath, os.FileMode(cfg.DirPerms)); err != nil {
+		if fsErr, ok := err.(*apperrors.FileSystemError); ok {
+			log.WithFields(log.Fields{
+				"argument": "workspacePath",
+				"path":     fsErr.Path,
+				"error":    fsErr.Unwrap(),
+			}).Fatalf("Critical file system error: %s", fsErr.Msg)
+		} else {
+			log.WithField("argument", "workspacePath").Fatalf("Error validating workspace path: %v", err)
+		}
+	}
+
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+	})
+	log.SetLevel(log.InfoLevel)
+
+	fmt.Println("O365 Mailbox Downloader")
+	log.Infof("Version: %s", "dev") // TODO: Find a way to pass version from main
+	log.Info("Application started.")
+
+	// Initialize components
+	o365Client := o365client.NewO365Client(
+		cfg.AccessToken,
+		time.Duration(cfg.HTTPClientTimeoutSeconds)*time.Second,
+		cfg.MaxRetries,
+		cfg.InitialBackoffSeconds,
+		cfg.APICallsPerSecond,
+		cfg.APIBurst,
+		rng, // Pass the local random number generator
+	)
+	emailProcessor := emailprocessor.NewEmailProcessor()
+	fileHandler := filehandler.NewFileHandler(
+		cfg.WorkspacePath,
+		o365Client,
+		cfg.LargeAttachmentThresholdMB,
+		cfg.ChunkSizeMB,
+		cfg.DirPerms,
+		cfg.FilePerms,
+	)
+
+	// 1. Create workspace
+	err := fileHandler.CreateWorkspace()
+	if err != nil {
+		if fsErr, ok := err.(*apperrors.FileSystemError); ok {
+			log.Fatalf("Critical file system error: %s (Path: %s, Original: %v)", fsErr.Msg, fsErr.Path, fsErr.Unwrap())
+		} else {
+			log.Errorf("Error creating workspace: %v", err)
+		}
+	}
+	log.WithField("path", cfg.WorkspacePath).Infof("Workspace created.")
+
+	// Load last run timestamp
+	var lastRunTimestamp string
+	if cfg.ProcessingMode == "incremental" {
+		var err error
+		lastRunTimestamp, err = fileHandler.LoadLastRunTimestamp()
+		if err != nil {
+			if fsErr, ok := err.(*apperrors.FileSystemError); ok {
+				log.Fatalf("Critical file system error: %s (Path: %s, Original: %v)", fsErr.Msg, fsErr.Path, fsErr.Unwrap())
+			} else {
+				log.Errorf("Error loading last run timestamp: %v", err)
+			}
+		}
+		if lastRunTimestamp != "" {
+			log.WithField("lastRunTimestamp", lastRunTimestamp).Infof("Fetching emails since last run.")
+		} else {
+			log.Info("No last run timestamp found. Fetching all available emails.")
+		}
+	} else {
+		log.Infof("Running in '%s' mode. Fetching all available emails from Inbox.", cfg.ProcessingMode)
+	}
+
+	// 2. Fetch emails
+	var messages []o365client.Message
+	messages, err = o365Client.GetMessages(ctx, cfg.MailboxName, lastRunTimestamp)
+	if err != nil {
+		switch e := err.(type) {
+		case *apperrors.APIError:
+			log.WithFields(log.Fields{
+				"errorType":  "APIError",
+				"statusCode": e.StatusCode,
+			}).Fatalf("O365 API error fetching messages: %s", e.Msg)
+		case *apperrors.AuthError:
+			log.WithFields(log.Fields{
+				"errorType": "AuthError",
+			}).Fatalf("Authentication failed: %s. Please check your access token.", e.Msg)
+		default:
+			// Check for context cancellation errors
+			if errors.Is(err, context.Canceled) {
+				log.WithField("errorType", "ContextCanceled").Fatalf("Message fetching cancelled by user.")
+			} else if errors.Is(err, context.DeadlineExceeded) {
+				log.WithField("errorType", "ContextDeadlineExceeded").Fatalf("Message fetching timed out.")
+			} else {
+				log.WithField("errorType", "UnknownError").Fatalf("Unknown error fetching messages: %v", err)
+			}
+		}
+	}
+	log.WithField("count", len(messages)).Infof("Fetched messages.")
+
+	// Semaphore to limit concurrent goroutines
+	semaphore := make(chan struct{}, cfg.MaxParallelDownloads)
+	var wg sync.WaitGroup
+
+	// 3. Process and save emails and attachments in parallel
+	var latestTimestamp time.Time
+	var mu sync.Mutex // Mutex to protect latestTimestamp
+
+	var processedFolderID, errorFolderID string
+	if cfg.ProcessingMode == "route" {
+		var err error
+		processedFolderID, err = o365Client.GetFolderID(ctx, cfg.MailboxName, cfg.ProcessedFolder)
+		if err != nil {
+			log.Fatalf("Failed to get processed folder ID: %v", err)
+		}
+		errorFolderID, err = o365Client.GetFolderID(ctx, cfg.MailboxName, cfg.ErrorFolder)
+		if err != nil {
+			log.Fatalf("Failed to get error folder ID: %v", err)
+		}
+	}
+
+	for _, msg := range messages {
+		wg.Add(1)
+		semaphore <- struct{}{}
+
+		go func(msg o365client.Message) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+
+			log.WithFields(log.Fields{"messageID": msg.ID, "subject": msg.Subject}).Infof("Processing message.")
+
+			var errs []string
+			var attachmentData []filehandler.AttachmentData
+
+			// 1. Clean Body
+			cleanedBody, err := emailProcessor.CleanHTML(msg.Body.Content)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("HTML cleaning failed: %v", err))
+				cleanedBody = msg.Body.Content // Use original on failure
+			}
+
+			bodyFileName, err := fileHandler.SaveBodyAsText(msg.ID, cleanedBody)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("Failed to save body text file: %v", err))
+			}
+
+			// 2. Process Attachments
+			if msg.HasAttachments {
+				attachments, err := o365Client.GetAttachments(ctx, cfg.MailboxName, msg.ID)
+				if err != nil {
+					errs = append(errs, fmt.Sprintf("Failed to get attachment list: %v", err))
+				} else {
+					var attWg sync.WaitGroup
+					for _, att := range attachments {
+						attWg.Add(1)
+						go func(att o365client.Attachment) {
+							defer attWg.Done()
+							newFileName, err := fileHandler.SaveAttachment(ctx, att.Name, msg.ID, att.DownloadURL, cfg.AccessToken, att.Size)
+							if err != nil {
+								mu.Lock()
+								errs = append(errs, fmt.Sprintf("Failed to save attachment '%s': %v", att.Name, err))
+								mu.Unlock()
+							} else {
+								mu.Lock()
+								attachmentData = append(attachmentData, filehandler.AttachmentData{
+									Name:        att.Name,
+									Size:        att.Size,
+									DownloadURL: newFileName,
+								})
+								mu.Unlock()
+							}
+						}(att)
+					}
+					attWg.Wait()
+				}
+			}
+
+			// 3. Determine final status
+			status := filehandler.StatusData{}
+			isError := len(errs) > 0
+			if isError {
+				status.State = "error"
+				status.Details = strings.Join(errs, "; ")
+			} else {
+				status.State = "success"
+				status.Details = "Message processed successfully."
+			}
+
+			// 4. Create and save the JSON report
+			emailData := filehandler.EmailData{
+				To:           make([]string, len(msg.ToRecipients)),
+				From:         msg.From.EmailAddress.Address,
+				Subject:      msg.Subject,
+				ReceivedDate: msg.ReceivedDateTime.Format(time.RFC3339),
+				BodyFile:     bodyFileName,
+				Attachments:  attachmentData,
+				Status:       status,
+			}
+			for i, recipient := range msg.ToRecipients {
+				emailData.To[i] = recipient.EmailAddress.Address
+			}
+
+			jsonSaveErr := fileHandler.SaveEmailAsJSON(msg.ID, emailData)
+			if jsonSaveErr != nil {
+				isError = true
+				log.Errorf("CRITICAL: Failed to save JSON report for msg %s: %v", msg.ID, jsonSaveErr)
+			}
+
+			// 5. Move the email
+			if cfg.ProcessingMode == "route" {
+				var moveErr error
+				if isError {
+					moveErr = o365Client.MoveMessage(ctx, cfg.MailboxName, msg.ID, errorFolderID)
+				} else {
+					moveErr = o365Client.MoveMessage(ctx, cfg.MailboxName, msg.ID, processedFolderID)
+				}
+
+				if moveErr != nil {
+					log.Errorf("CRITICAL: Failed to move message %s to target folder: %v", msg.ID, moveErr)
+					return // Don't update timestamp if move fails
+				}
+			}
+
+			// 6. Update timestamp only on complete success
+			if !isError {
+				mu.Lock()
+				if msg.ReceivedDateTime.After(latestTimestamp) {
+					latestTimestamp = msg.ReceivedDateTime
+				}
+				mu.Unlock()
+			}
+		}(msg)
+	}
+
+	wg.Wait() // Wait for all message processing goroutines to complete
+
+	// If no messages were fetched, use current time as latest timestamp
+	if latestTimestamp.IsZero() {
+		latestTimestamp = time.Now()
+	}
+
+	if cfg.ProcessingMode == "incremental" {
+		// Save latest timestamp for next run
+		err := fileHandler.SaveLastRunTimestamp(latestTimestamp.Format(time.RFC3339))
+		if err != nil {
+			if fsErr, ok := err.(*apperrors.FileSystemError); ok {
+				log.WithFields(log.Fields{
+					"errorType": "FileSystemError",
+					"path":      fsErr.Path,
+					"error":     fsErr.Unwrap(),
+				}).Errorf("File system error saving last run timestamp: %s", fsErr.Msg)
+			} else {
+				log.WithField("error", err).Errorf("Error saving last run timestamp.")
+			}
+		}
+	}
+
+	log.Info("Application finished.")
+}
+
+// IsValidEmail checks if a string is a valid email address.
+func IsValidEmail(email string) bool {
+	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+	return emailRegex.MatchString(email)
+}
+
+// RunHealthCheck handles the logic for the health check mode.
+func RunHealthCheck(ctx context.Context, client *o365client.O365Client, mailboxName string) {
+	log.WithField("mailbox", mailboxName).Info("Attempting to connect to mailbox and retrieve statistics...")
+
+	messageCount, err := client.GetMailboxStatistics(ctx, mailboxName)
+	if err != nil {
+		switch e := err.(type) {
+		case *apperrors.APIError:
+			log.WithFields(log.Fields{
+				"errorType":  "APIError",
+				"statusCode": e.StatusCode,
+			}).Errorf("O365 API error during connect check: %s", e.Msg)
+		case *apperrors.AuthError:
+			log.WithFields(log.Fields{
+				"errorType": "AuthError",
+			}).Errorf("Authentication failed during connect check: %s. Please check your access token.", e.Msg)
+		default:
+			if errors.Is(err, context.Canceled) {
+				log.WithField("errorType", "ContextCanceled").Errorf("Connect check cancelled by user.")
+			} else if errors.Is(err, context.DeadlineExceeded) {
+				log.WithField("errorType", "ContextDeadlineExceeded").Errorf("Connect check timed out.")
+			} else {
+				log.WithField("errorType", "UnknownError").Errorf("Unknown error during connect check: %v", err)
+			}
+		}
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"mailbox":      mailboxName,
+		"messageCount": messageCount,
+	}).Info("Mailbox connectivity successful. Statistics:")
+	fmt.Printf("\nMailbox: %s\n", mailboxName)
+	fmt.Printf("Total Messages: %d\n", messageCount)
+	// Add more statistics here as needed
+}
+
+// validateWorkspacePath checks and creates the workspace directory.
+func validateWorkspacePath(path string, dirPerms os.FileMode) error {
+	if path == "" {
+		return fmt.Errorf("workspace path cannot be empty")
+	}
+	// Check if the path is absolute
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("workspace path must be an absolute path: %s", path)
+	}
+	// Attempt to create the directory if it doesn't exist
+	if err := os.MkdirAll(path, dirPerms); err != nil {
+		return fmt.Errorf("failed to create workspace directory %s: %w", path, err)
+	}
+	// Basic check to ensure it's a directory and we can access it
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat workspace directory %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("workspace path %s is not a directory", path)
+	}
+	return nil
+}

--- a/filehandler/filehandler.go
+++ b/filehandler/filehandler.go
@@ -2,6 +2,7 @@ package filehandler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -22,45 +23,90 @@ type FileHandler struct {
 	o365Client               o365client.O365ClientInterface
 	largeAttachmentThreshold int // in bytes
 	chunkSize                int // in bytes
+	dirPerms                 os.FileMode
+	filePerms                os.FileMode
 }
 
-func NewFileHandler(workspacePath string, o365Client o365client.O365ClientInterface, largeAttachmentThresholdMB, chunkSizeMB int) *FileHandler {
+func NewFileHandler(workspacePath string, o365Client o365client.O365ClientInterface, largeAttachmentThresholdMB, chunkSizeMB int, dirPerms, filePerms int) *FileHandler {
 	return &FileHandler{
 		workspacePath:            workspacePath,
 		o365Client:               o365Client,
 		largeAttachmentThreshold: largeAttachmentThresholdMB * 1024 * 1024,
 		chunkSize:                chunkSizeMB * 1024 * 1024,
+		dirPerms:                 os.FileMode(dirPerms),
+		filePerms:                os.FileMode(filePerms),
 	}
 }
 
 // CreateWorkspace creates the unique workspace directory.
 func (fh *FileHandler) CreateWorkspace() error {
-	err := os.MkdirAll(fh.workspacePath, 0755)
+	err := os.MkdirAll(fh.workspacePath, fh.dirPerms)
 	if err != nil {
 		return &apperrors.FileSystemError{Path: fh.workspacePath, Msg: "failed to create workspace directory", Err: err}
 	}
 	return nil
 }
 
-// SaveEmailBody saves the cleaned email body to a file.
-func (fh *FileHandler) SaveEmailBody(subject, messageID, bodyContent string) error {
-	fileName := fmt.Sprintf("%s_%s.txt", sanitizeFileName(subject), messageID)
+// AttachmentData defines the structure for attachment information in the JSON output.
+type AttachmentData struct {
+	Name        string `json:"name"`
+	Size        int    `json:"size"`
+	DownloadURL string `json:"downloadUrl"`
+}
+
+// StatusData defines the structure for processing status in the JSON output.
+type StatusData struct {
+	State   string `json:"state"`
+	Details string `json:"details"`
+}
+
+// EmailData defines the structure for the JSON output file.
+type EmailData struct {
+	To           []string         `json:"to"`
+	From         string           `json:"from"`
+	Subject      string           `json:"subject"`
+	ReceivedDate string           `json:"receivedDate"`
+	BodyFile     string           `json:"bodyFile"`
+	Attachments  []AttachmentData `json:"attachments"`
+	Status       StatusData       `json:"status"`
+}
+
+// SaveBodyAsText saves the email body to a text file and returns the file name.
+func (fh *FileHandler) SaveBodyAsText(messageID, bodyContent string) (string, error) {
+	fileName := fmt.Sprintf("%s_body.txt", messageID)
 	filePath := filepath.Join(fh.workspacePath, fileName)
-	err := os.WriteFile(filePath, []byte(bodyContent), 0644)
+	err := os.WriteFile(filePath, []byte(bodyContent), fh.filePerms)
 	if err != nil {
-		return &apperrors.FileSystemError{Path: filePath, Msg: "failed to save email body", Err: err}
+		return "", &apperrors.FileSystemError{Path: filePath, Msg: "failed to save email body text file", Err: err}
+	}
+	return fileName, nil
+}
+
+// SaveEmailAsJSON saves the email data as a JSON file.
+func (fh *FileHandler) SaveEmailAsJSON(messageID string, data EmailData) error {
+	fileName := fmt.Sprintf("%s.json", messageID)
+	filePath := filepath.Join(fh.workspacePath, fileName)
+
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal email data to JSON: %w", err)
+	}
+
+	err = os.WriteFile(filePath, jsonData, fh.filePerms)
+	if err != nil {
+		return &apperrors.FileSystemError{Path: filePath, Msg: "failed to save email JSON file", Err: err}
 	}
 	return nil
 }
 
-// SaveAttachment saves an attachment to a file.
-func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messageID, downloadURL, accessToken string, attachmentSize int) error { // ctx added
+// SaveAttachment saves an attachment to a file and returns the new file name.
+func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messageID, downloadURL, accessToken string, attachmentSize int) (string, error) { // ctx added
 	fileName := fmt.Sprintf("%s_%s_%s", sanitizeFileName(attachmentName), messageID, attachmentName)
 	filePath := filepath.Join(fh.workspacePath, fileName)
 
-	out, err := os.Create(filePath)
+	out, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fh.filePerms)
 	if err != nil {
-		return &apperrors.FileSystemError{Path: filePath, Msg: "failed to create file for attachment", Err: err}
+		return "", &apperrors.FileSystemError{Path: filePath, Msg: "failed to create file for attachment", Err: err}
 	}
 	defer out.Close()
 
@@ -68,7 +114,7 @@ func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messa
 		// Existing direct download logic for smaller attachments
 		req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil) // Pass ctx to request
 		if err != nil {
-			return fmt.Errorf("failed to create HTTP request for attachment download: %w", err)
+			return "", fmt.Errorf("failed to create HTTP request for attachment download: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+accessToken)
 
@@ -76,30 +122,30 @@ func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messa
 		if err != nil {
 			// Check if the error from DoRequestWithRetry is already a custom error
 			if apiErr, ok := err.(*apperrors.APIError); ok {
-				return apiErr // Return the specific API error
+				return "", apiErr // Return the specific API error
 			}
 			if authErr, ok := err.(*apperrors.AuthError); ok {
-				return authErr // Return the specific Auth error
+				return "", authErr // Return the specific Auth error
 			}
 			// Check for context cancellation errors
 			if errors.Is(err, context.Canceled) {
-				return fmt.Errorf("attachment download cancelled by user: %w", err)
+				return "", fmt.Errorf("attachment download cancelled by user: %w", err)
 			} else if errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("attachment download timed out: %w", err)
+				return "", fmt.Errorf("attachment download timed out: %w", err)
 			} else {
 				// Otherwise, wrap in a generic error with more context
-				return fmt.Errorf("failed to download attachment from %s: %w", downloadURL, err)
+				return "", fmt.Errorf("failed to download attachment from %s: %w", downloadURL, err)
 			}
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return &apperrors.APIError{StatusCode: resp.StatusCode, Msg: fmt.Sprintf("failed to download small attachment from %s", downloadURL)}
+			return "", &apperrors.APIError{StatusCode: resp.StatusCode, Msg: fmt.Sprintf("failed to download small attachment from %s", downloadURL)}
 		}
 
 		_, err = io.Copy(out, resp.Body)
 		if err != nil {
-			return &apperrors.FileSystemError{Path: filePath, Msg: "failed to write attachment content to file", Err: err}
+			return "", &apperrors.FileSystemError{Path: filePath, Msg: "failed to write attachment content to file", Err: err}
 		}
 		log.WithField("attachmentName", attachmentName).Infof("Successfully downloaded small attachment.")
 	} else {
@@ -110,7 +156,7 @@ func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messa
 			select {
 			case <-ctx.Done():
 				log.WithField("error", ctx.Err()).Warn("Context cancelled during large attachment download.")
-				return ctx.Err() // Return context cancellation error
+				return "", ctx.Err() // Return context cancellation error
 			default:
 				// Continue
 			}
@@ -122,7 +168,7 @@ func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messa
 
 			req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil) // Pass ctx to request
 			if err != nil {
-				return fmt.Errorf("failed to create HTTP request for attachment chunk: %w", err)
+				return "", fmt.Errorf("failed to create HTTP request for attachment chunk: %w", err)
 			}
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 			req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", downloadedBytes, endByte))
@@ -131,31 +177,31 @@ func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messa
 			if err != nil {
 				// Check if the error from DoRequestWithRetry is already a custom error
 				if apiErr, ok := err.(*apperrors.APIError); ok {
-					return apiErr // Return the specific API error
+					return "", apiErr // Return the specific API error
 				}
 				if authErr, ok := err.(*apperrors.AuthError); ok {
-					return authErr // Return the specific Auth error
+					return "", authErr // Return the specific Auth error
 				}
 				// Check for context cancellation errors
 				if errors.Is(err, context.Canceled) {
-					return fmt.Errorf("attachment download cancelled by user: %w", err)
+					return "", fmt.Errorf("attachment download cancelled by user: %w", err)
 				} else if errors.Is(err, context.DeadlineExceeded) {
-					return fmt.Errorf("attachment download timed out: %w", err)
+					return "", fmt.Errorf("attachment download timed out: %w", err)
 				} else {
 					// Otherwise, wrap in a generic error with more context
-					return fmt.Errorf("failed to download attachment chunk from %s (range %d-%d): %w", downloadURL, downloadedBytes, endByte, err)
+					return "", fmt.Errorf("failed to download attachment chunk from %s (range %d-%d): %w", downloadURL, downloadedBytes, endByte, err)
 				}
 			}
 			defer resp.Body.Close() // Defer inside the loop, will be closed on each iteration
 
 			// Graph API returns 206 Partial Content for range requests, 200 OK if range is ignored or full file.
 			if resp.StatusCode != http.StatusPartialContent && resp.StatusCode != http.StatusOK {
-				return &apperrors.APIError{StatusCode: resp.StatusCode, Msg: fmt.Sprintf("failed to download attachment chunk from %s (range %d-%d)", downloadURL, downloadedBytes, endByte)}
+				return "", &apperrors.APIError{StatusCode: resp.StatusCode, Msg: fmt.Sprintf("failed to download attachment chunk from %s (range %d-%d)", downloadURL, downloadedBytes, endByte)}
 			}
 
 			n, err := io.Copy(out, resp.Body)
 			if err != nil {
-				return &apperrors.FileSystemError{Path: filePath, Msg: "failed to write attachment chunk content to file", Err: err}
+				return "", &apperrors.FileSystemError{Path: filePath, Msg: "failed to write attachment chunk content to file", Err: err}
 			}
 			downloadedBytes += n
 			log.WithFields(log.Fields{"downloadedBytes": n, "attachmentName": attachmentName, "totalDownloaded": downloadedBytes, "attachmentSize": attachmentSize}).Debug("Downloaded bytes for attachment.")
@@ -163,13 +209,13 @@ func (fh *FileHandler) SaveAttachment(ctx context.Context, attachmentName, messa
 		log.WithField("attachmentName", attachmentName).Infof("Successfully downloaded large attachment.")
 	}
 
-	return nil
+	return fileName, nil
 }
 
 // SaveLastRunTimestamp saves the timestamp of the last successful run.
 func (fh *FileHandler) SaveLastRunTimestamp(timestamp string) error {
 	filePath := filepath.Join(fh.workspacePath, "last_run_timestamp.txt")
-	err := os.WriteFile(filePath, []byte(timestamp), 0644)
+	err := os.WriteFile(filePath, []byte(timestamp), fh.filePerms)
 	if err != nil {
 		return &apperrors.FileSystemError{Path: filePath, Msg: "failed to save last run timestamp", Err: err}
 	}

--- a/main.go
+++ b/main.go
@@ -2,71 +2,51 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"math/rand" // Added for seeding random number generator
 	"os"
 	"os/signal"
-	"path/filepath"
-	"regexp"
-	"sync"
+	"strings"
 	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
-	"o365mbx/apperrors"
-	"o365mbx/emailprocessor"
-	"o365mbx/filehandler"
+	"o365mbx/config"
+	"o365mbx/engine"
 	"o365mbx/o365client"
 )
 
 var version = "dev" // Global variable to hold the version
 
-// isValidEmail checks if a string is a valid email address.
-func isValidEmail(email string) bool {
-	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
-	return emailRegex.MatchString(email)
-}
-
-// validateWorkspacePath checks and creates the workspace directory.
-func validateWorkspacePath(path string) error {
-	if path == "" {
-		return fmt.Errorf("workspace path cannot be empty")
-	}
-	// Check if the path is absolute
-	if !filepath.IsAbs(path) {
-		return fmt.Errorf("workspace path must be an absolute path: %s", path)
-	}
-	// Attempt to create the directory if it doesn't exist
-	if err := os.MkdirAll(path, 0755); err != nil {
-		return fmt.Errorf("failed to create workspace directory %s: %w", path, err)
-	}
-	// Basic check to ensure it's a directory and we can access it
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("failed to stat workspace directory %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("workspace path %s is not a directory", path)
-	}
-	return nil
-}
-
 func main() {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano())) // Create a local random number generator
 
-	accessToken := flag.String("token", "", "Access token for O356 API")
-	mailboxName := flag.String("mailbox", "", "Mailbox name (e.g., name@domain.com)")
-	workspacePath := flag.String("workspace", "", "Unique folder to store all artifacts")
-	timeoutSeconds := flag.Int("timeout", 120, "HTTP client timeout in seconds (default: 120)")
-	maxParallelDownloads := flag.Int("parallel", 10, "Maximum number of parallel downloads (default: 10)")
 	configPath := flag.String("config", "", "Path to the configuration file (JSON)")
-	apiCallsPerSecond := flag.Float64("api-rate", 0, "API calls per second for client-side rate limiting (default: 5.0)")
-	apiBurst := flag.Int("api-burst", 0, "API burst capacity for client-side rate limiting (default: 10)")
 	displayVersion := flag.Bool("version", false, "Display application version")
 	healthCheck := flag.Bool("healthcheck", false, "Perform a health check on the mailbox and exit") // New flag for healthcheck
+
+	// Define flags for settings that can be in the config file or command line
+	mailboxName := flag.String("mailbox", "", "Mailbox name (e.g., name@domain.com)")
+	workspacePath := flag.String("workspace", "", "Unique folder to store all artifacts")
+	tokenString := flag.String("token-string", "", "Directly provides the JWT token as a string.")
+	tokenFile := flag.String("token-file", "", "Specifies a file from which to read the JWT token.")
+	tokenEnv := flag.Bool("token-env", false, "Instructs the application to read the JWT token from the JWT_TOKEN environment variable.")
+	removeTokenFile := flag.Bool("remove-token-file", false, "Remove the token file after all messages have been processed for security purposes.")
+	processedFolder := flag.String("processed-folder", "", "Folder to move processed emails to")
+	errorFolder := flag.String("error-folder", "", "Folder to move emails that failed to process")
+	processingMode := flag.String("processing-mode", "", "Processing mode: full, incremental, or route")
+	timeoutSeconds := flag.Int("timeout", 0, "HTTP client timeout in seconds")
+	maxParallelDownloads := flag.Int("parallel", 0, "Maximum number of parallel downloads")
+	apiCallsPerSecond := flag.Float64("api-rate", 0, "API calls per second for client-side rate limiting (default: 5.0)")
+	apiBurst := flag.Int("api-burst", 0, "API burst capacity for client-side rate limiting (default: 10)")
+	maxRetries := flag.Int("max-retries", 0, "Maximum number of retries for failed API calls")
+	initialBackoffSeconds := flag.Int("initial-backoff-seconds", 0, "Initial backoff in seconds for retries")
+	largeAttachmentThresholdMB := flag.Int("large-attachment-threshold-mb", 0, "Threshold in MB for large attachments")
+	chunkSizeMB := flag.Int("chunk-size-mb", 0, "Chunk size in MB for large attachment downloads")
+	dirPerms := flag.Int("dir-perms", 0, "Permissions for created directories (octal)")
+	filePerms := flag.Int("file-perms", 0, "Permissions for created files (octal)")
 	flag.Parse()
 
 	if *displayVersion {
@@ -74,28 +54,116 @@ func main() {
 		os.Exit(0) // Exit cleanly after displaying version
 	}
 
-	cfg, err := LoadConfig(*configPath)
+	cfg, err := config.LoadConfig(*configPath)
 	if err != nil {
 		log.Fatalf("Error loading configuration: %v", err)
 	}
 
 	// Override config values with command-line arguments if provided
-	if *timeoutSeconds != 120 { // If user explicitly set timeoutSeconds
+	if *tokenString != "" {
+		cfg.TokenString = *tokenString
+	}
+	if *tokenFile != "" {
+		cfg.TokenFile = *tokenFile
+	}
+	if *tokenEnv {
+		cfg.TokenEnv = *tokenEnv
+	}
+	if *removeTokenFile {
+		cfg.RemoveTokenFile = *removeTokenFile
+	}
+	if *mailboxName != "" {
+		cfg.MailboxName = *mailboxName
+	}
+	if *workspacePath != "" {
+		cfg.WorkspacePath = *workspacePath
+	}
+	if *processedFolder != "" {
+		cfg.ProcessedFolder = *processedFolder
+	}
+	if *errorFolder != "" {
+		cfg.ErrorFolder = *errorFolder
+	}
+	if *processingMode != "" {
+		cfg.ProcessingMode = *processingMode
+	}
+	if *timeoutSeconds != 0 {
 		cfg.HTTPClientTimeoutSeconds = *timeoutSeconds
 	}
-	if *maxParallelDownloads != 10 { // If user explicitly set maxParallelDownloads
+	if *maxParallelDownloads != 0 {
 		cfg.MaxParallelDownloads = *maxParallelDownloads
 	}
-	if *apiCallsPerSecond != 0 { // If user explicitly set apiCallsPerSecond
+	if *apiCallsPerSecond != 0 {
 		cfg.APICallsPerSecond = *apiCallsPerSecond
 	}
-	if *apiBurst != 0 { // If user explicitly set apiBurst
+	if *apiBurst != 0 {
 		cfg.APIBurst = *apiBurst
+	}
+	if *maxRetries != 0 {
+		cfg.MaxRetries = *maxRetries
+	}
+	if *initialBackoffSeconds != 0 {
+		cfg.InitialBackoffSeconds = *initialBackoffSeconds
+	}
+	if *largeAttachmentThresholdMB != 0 {
+		cfg.LargeAttachmentThresholdMB = *largeAttachmentThresholdMB
+	}
+	if *chunkSizeMB != 0 {
+		cfg.ChunkSizeMB = *chunkSizeMB
+	}
+	if *dirPerms != 0 {
+		cfg.DirPerms = *dirPerms
+	}
+	if *filePerms != 0 {
+		cfg.FilePerms = *filePerms
 	}
 
 	// Validate loaded configuration
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("Invalid configuration: %v", err)
+	}
+
+	if cfg.RemoveTokenFile && cfg.TokenFile != "" {
+		defer func() {
+			log.Infof("Removing token file: %s", cfg.TokenFile)
+			if err := os.Remove(cfg.TokenFile); err != nil {
+				log.Errorf("Failed to remove token file: %v", err)
+			}
+		}()
+	}
+
+	// --- Token Acquisition and Validation ---
+	tokenSourceCount := 0
+	if cfg.TokenString != "" {
+		tokenSourceCount++
+	}
+	if cfg.TokenFile != "" {
+		tokenSourceCount++
+	}
+	if cfg.TokenEnv {
+		tokenSourceCount++
+	}
+
+	if tokenSourceCount == 0 {
+		log.Fatalf("No token source specified. Please use one of -token-string, -token-file, or -token-env.")
+	}
+	if tokenSourceCount > 1 {
+		log.Fatalf("Multiple token sources specified. Please use only one of -token-string, -token-file, or -token-env.")
+	}
+
+	if cfg.TokenString != "" {
+		cfg.AccessToken = cfg.TokenString
+	} else if cfg.TokenFile != "" {
+		tokenBytes, err := os.ReadFile(cfg.TokenFile)
+		if err != nil {
+			log.Fatalf("Failed to read token from file %s: %v", cfg.TokenFile, err)
+		}
+		cfg.AccessToken = strings.TrimSpace(string(tokenBytes))
+	} else if cfg.TokenEnv {
+		cfg.AccessToken = os.Getenv("JWT_TOKEN")
+		if cfg.AccessToken == "" {
+			log.Fatalf("Token source set to env, but JWT_TOKEN environment variable is not set or empty.")
+		}
 	}
 
 	// Set up context for graceful shutdown
@@ -111,11 +179,11 @@ func main() {
 	}()
 
 	// Argument validation (common for both modes: healthcheck and download)
-	if *accessToken == "" {
+	if cfg.AccessToken == "" {
 		log.WithField("argument", "accessToken").Fatalf("Error: Access token is missing.")
 	}
-	if !isValidEmail(*mailboxName) {
-		log.WithField("argument", "mailboxName").Fatalf("Error: Invalid mailbox name format: %s", *mailboxName)
+	if !engine.IsValidEmail(cfg.MailboxName) {
+		log.WithField("argument", "mailboxName").Fatalf("Error: Invalid mailbox name format: %s", cfg.MailboxName)
 	}
 
 	// Health Check Mode
@@ -130,7 +198,7 @@ func main() {
 
 		// Initialize o365Client for health check
 		o365Client := o365client.NewO365Client(
-			*accessToken,
+			cfg.AccessToken,
 			time.Duration(cfg.HTTPClientTimeoutSeconds)*time.Second,
 			cfg.MaxRetries,
 			cfg.InitialBackoffSeconds,
@@ -139,310 +207,12 @@ func main() {
 			rng,
 		)
 
-		runHealthCheckMode(ctx, o365Client, *mailboxName)
+		engine.RunHealthCheck(ctx, o365Client, cfg.MailboxName)
 		os.Exit(0) // Exit after health check
 	}
 
 	// Normal Download Mode
-	runDownloadMode(ctx, cfg, *accessToken, *mailboxName, *workspacePath, rng)
+	engine.Run(ctx, cfg, rng)
 }
 
-// runDownloadMode handles the main logic for downloading emails and attachments.
-func runDownloadMode(ctx context.Context, cfg *Config, accessToken, mailboxName, workspacePath string, rng *rand.Rand) {
-	// Argument validation specific to download mode
-	if err := validateWorkspacePath(workspacePath); err != nil {
-		if fsErr, ok := err.(*apperrors.FileSystemError); ok {
-			log.WithFields(log.Fields{
-				"argument": "workspacePath",
-				"path":     fsErr.Path,
-				"error":    fsErr.Unwrap(),
-			}).Fatalf("Critical file system error: %s", fsErr.Msg)
-		} else {
-			log.WithField("argument", "workspacePath").Fatalf("Error validating workspace path: %v", err)
-		}
-	}
-
-	log.SetFormatter(&log.TextFormatter{
-		FullTimestamp: true,
-	})
-	log.SetLevel(log.InfoLevel)
-
-	fmt.Println("O365 Mailbox Downloader")
-	log.Infof("Version: %s", version) // Display the version
-	log.Info("Application started.")
-
-	// Initialize components
-	o365Client := o365client.NewO365Client(
-		accessToken,
-		time.Duration(cfg.HTTPClientTimeoutSeconds)*time.Second,
-		cfg.MaxRetries,
-		cfg.InitialBackoffSeconds,
-		cfg.APICallsPerSecond,
-		cfg.APIBurst,
-		rng, // Pass the local random number generator
-	)
-	emailProcessor := emailprocessor.NewEmailProcessor()
-	fileHandler := filehandler.NewFileHandler(
-		workspacePath,
-		o365Client,
-		cfg.LargeAttachmentThresholdMB,
-		cfg.ChunkSizeMB,
-	)
-
-	// 1. Create workspace
-	err := fileHandler.CreateWorkspace()
-	if err != nil {
-		if fsErr, ok := err.(*apperrors.FileSystemError); ok {
-			log.Fatalf("Critical file system error: %s (Path: %s, Original: %v)", fsErr.Msg, fsErr.Path, fsErr.Unwrap())
-		} else {
-			log.Errorf("Error creating workspace: %v", err)
-		}
-	}
-	log.WithField("path", workspacePath).Infof("Workspace created.")
-
-	// Load last run timestamp
-	var lastRunTimestamp string
-	lastRunTimestamp, err = fileHandler.LoadLastRunTimestamp()
-	if err != nil {
-		if fsErr, ok := err.(*apperrors.FileSystemError); ok {
-			log.Fatalf("Critical file system error: %s (Path: %s, Original: %v)", fsErr.Msg, fsErr.Path, fsErr.Unwrap())
-		} else {
-			log.Errorf("Error loading last run timestamp: %v", err)
-		}
-	}
-	if lastRunTimestamp != "" {
-		log.WithField("lastRunTimestamp", lastRunTimestamp).Infof("Fetching emails since last run.")
-	} else {
-		log.Info("No last run timestamp found. Fetching all available emails.")
-	}
-
-	// 2. Fetch emails
-	var messages []o365client.Message
-	messages, err = o365Client.GetMessages(ctx, mailboxName, lastRunTimestamp)
-	if err != nil {
-		switch e := err.(type) {
-		case *apperrors.APIError:
-			log.WithFields(log.Fields{
-				"errorType":  "APIError",
-				"statusCode": e.StatusCode,
-			}).Fatalf("O365 API error fetching messages: %s", e.Msg)
-		case *apperrors.AuthError:
-			log.WithFields(log.Fields{
-				"errorType": "AuthError",
-			}).Fatalf("Authentication failed: %s. Please check your access token.", e.Msg)
-		default:
-			// Check for context cancellation errors
-			if errors.Is(err, context.Canceled) {
-				log.WithField("errorType", "ContextCanceled").Fatalf("Message fetching cancelled by user.")
-			} else if errors.Is(err, context.DeadlineExceeded) {
-				log.WithField("errorType", "ContextDeadlineExceeded").Fatalf("Message fetching timed out.")
-			} else {
-				log.WithField("errorType", "UnknownError").Fatalf("Unknown error fetching messages: %v", err)
-			}
-		}
-	}
-	log.WithField("count", len(messages)).Infof("Fetched messages.")
-
-	// Semaphore to limit concurrent goroutines
-	semaphore := make(chan struct{}, cfg.MaxParallelDownloads)
-	var wg sync.WaitGroup
-
-	// 3. Process and save emails and attachments in parallel
-	var latestTimestamp time.Time
-	var mu sync.Mutex // Mutex to protect latestTimestamp
-
-	for _, msg := range messages {
-		wg.Add(1)
-		semaphore <- struct{}{}
-
-		go func(msg o365client.Message) {
-			defer wg.Done()
-			defer func() { <-semaphore }()
-
-			log.WithFields(log.Fields{"messageID": msg.ID, "subject": msg.Subject}).Infof("Processing message.")
-
-			var cleanedBody string
-			cleanedBody, err = emailProcessor.CleanHTML(msg.Body.Content)
-			if err != nil {
-				log.WithFields(log.Fields{"messageID": msg.ID, "error": err}).Warn("Failed to clean HTML for message.")
-				cleanedBody = msg.Body.Content // Use original if cleaning fails
-			}
-			err = fileHandler.SaveEmailBody(msg.Subject, msg.ID, cleanedBody)
-			if err != nil {
-				if fsErr, ok := err.(*apperrors.FileSystemError); ok {
-					log.WithFields(log.Fields{
-						"messageID": msg.ID,
-						"path":      fsErr.Path,
-						"error":     fsErr.Unwrap(),
-					}).Errorf("File system error saving email body: %s", fsErr.Msg)
-				} else {
-					log.WithFields(log.Fields{
-						"messageID": msg.ID,
-						"error":     err,
-					}).Errorf("Error saving email body.")
-				}
-			}
-
-			// Download and save attachments
-			if msg.HasAttachments {
-				var attachments []o365client.Attachment
-				attachments, err = o365Client.GetAttachments(ctx, mailboxName, msg.ID)
-				if err != nil {
-					switch e := err.(type) {
-					case *apperrors.APIError:
-						log.WithFields(log.Fields{
-							"messageID":  msg.ID,
-							"errorType":  "APIError",
-							"statusCode": e.StatusCode,
-						}).Errorf("O365 API error fetching attachments: %s", e.Msg)
-					case *apperrors.AuthError:
-						log.WithFields(log.Fields{
-							"messageID": msg.ID,
-							"errorType": "AuthError",
-						}).Errorf("Authentication failed for attachments: %s", e.Msg)
-					default:
-						// Check for context cancellation errors
-						if errors.Is(err, context.Canceled) {
-							log.WithFields(log.Fields{
-								"messageID": msg.ID,
-								"errorType": "ContextCanceled",
-							}).Errorf("Attachment fetching cancelled by user.")
-						} else if errors.Is(err, context.DeadlineExceeded) {
-							log.WithFields(log.Fields{
-								"messageID": msg.ID,
-								"errorType": "ContextDeadlineExceeded",
-							}).Errorf("Attachment fetching timed out.")
-						} else {
-							log.WithFields(log.Fields{
-								"messageID": msg.ID,
-								"errorType": "UnknownError",
-								"error":     err,
-							}).Errorf("Unknown error fetching attachments.")
-						}
-					}
-					return // Skip attachments for this message if fetching fails
-				}
-				log.WithFields(log.Fields{"count": len(attachments), "messageID": msg.ID}).Infof("Found attachments.")
-
-				var attWg sync.WaitGroup // WaitGroup for attachments within this message
-				for _, att := range attachments {
-					attWg.Add(1)
-					go func(att o365client.Attachment) {
-						defer attWg.Done()
-						log.WithFields(log.Fields{"attachmentName": att.Name, "messageID": msg.ID}).Infof("Downloading attachment.")
-						err = fileHandler.SaveAttachment(ctx, att.Name, msg.ID, att.DownloadURL, accessToken, att.Size)
-						if err != nil {
-							switch e := err.(type) {
-							case *apperrors.FileSystemError:
-								log.WithFields(log.Fields{
-									"attachmentName": att.Name,
-									"messageID":      msg.ID,
-									"errorType":      "FileSystemError",
-									"path":           e.Path,
-									"error":          e.Unwrap(),
-								}).Errorf("File system error saving attachment: %s", e.Msg)
-							case *apperrors.APIError:
-								log.WithFields(log.Fields{
-									"attachmentName": att.Name,
-									"messageID":      msg.ID,
-									"errorType":      "APIError",
-									"statusCode":     e.StatusCode,
-								}).Errorf("API error downloading attachment: %s", e.Msg)
-							default:
-								if errors.Is(err, context.Canceled) {
-									log.WithFields(log.Fields{
-										"attachmentName": att.Name,
-										"messageID":      msg.ID,
-										"errorType":      "ContextCanceled",
-									}).Errorf("Attachment download cancelled by user.")
-								} else if errors.Is(err, context.DeadlineExceeded) {
-									log.WithFields(log.Fields{
-										"attachmentName": att.Name,
-										"messageID":      msg.ID,
-										"errorType":      "ContextDeadlineExceeded",
-									}).Errorf("Attachment download timed out.")
-								} else {
-									log.WithFields(log.Fields{
-										"attachmentName": att.Name,
-										"messageID":      msg.ID,
-										"errorType":      "UnknownError",
-										"error":          err,
-									}).Errorf("Unknown error saving attachment.")
-								}
-							}
-						}
-					}(att)
-				}
-				attWg.Wait() // Wait for all attachments of this message to complete
-			}
-
-			// Update latestTimestamp safely
-			mu.Lock()
-			if msg.ReceivedDateTime.After(latestTimestamp) {
-				latestTimestamp = msg.ReceivedDateTime
-			}
-			mu.Unlock()
-
-		}(msg)
-	}
-
-	wg.Wait() // Wait for all message processing goroutines to complete
-
-	// If no messages were fetched, use current time as latest timestamp
-	if latestTimestamp.IsZero() {
-		latestTimestamp = time.Now()
-	}
-
-	// Save latest timestamp for next run
-	err = fileHandler.SaveLastRunTimestamp(latestTimestamp.Format(time.RFC3339))
-	if err != nil {
-		if fsErr, ok := err.(*apperrors.FileSystemError); ok {
-			log.WithFields(log.Fields{
-				"errorType": "FileSystemError",
-				"path":      fsErr.Path,
-				"error":     fsErr.Unwrap(),
-			}).Errorf("File system error saving last run timestamp: %s", fsErr.Msg)
-		} else {
-			log.WithField("error", err).Errorf("Error saving last run timestamp.")
-		}
-	}
-
-	log.Info("Application finished.")
-}
-
-// runHealthCheckMode handles the logic for the health check mode.
-func runHealthCheckMode(ctx context.Context, client *o365client.O365Client, mailboxName string) {
-	log.WithField("mailbox", mailboxName).Info("Attempting to connect to mailbox and retrieve statistics...")
-
-	messageCount, err := client.GetMailboxStatistics(ctx, mailboxName)
-	if err != nil {
-		switch e := err.(type) {
-		case *apperrors.APIError:
-			log.WithFields(log.Fields{
-				"errorType":  "APIError",
-				"statusCode": e.StatusCode,
-			}).Errorf("O365 API error during connect check: %s", e.Msg)
-		case *apperrors.AuthError:
-			log.WithFields(log.Fields{
-				"errorType": "AuthError",
-			}).Errorf("Authentication failed during connect check: %s. Please check your access token.", e.Msg)
-		default:
-			if errors.Is(err, context.Canceled) {
-				log.WithField("errorType", "ContextCanceled").Errorf("Connect check cancelled by user.")
-			} else if errors.Is(err, context.DeadlineExceeded) {
-				log.WithField("errorType", "ContextDeadlineExceeded").Errorf("Connect check timed out.")
-			} else {
-				log.WithField("errorType", "UnknownError").Errorf("Unknown error during connect check: %v", err)
-			}
-		}
-		return
-	}
-
-	log.WithFields(log.Fields{
-		"mailbox":      mailboxName,
-		"messageCount": messageCount,
-	}).Info("Mailbox connectivity successful. Statistics:")
-	fmt.Printf("\nMailbox: %s\n", mailboxName)
-	fmt.Printf("Total Messages: %d\n", messageCount)
-	// Add more statistics here as needed
-}
+// No more `runHealthCheckMode` in main.go


### PR DESCRIPTION
This commit changes how the email body is saved.

Instead of being embedded in the main JSON output, the cleaned, plain-text body is now saved to a separate `.txt` file (e.g., `<messageID>_body.txt`).

The main JSON file has been updated to include a `bodyFile` field, which contains the filename of the corresponding body text file. This makes the JSON a cleaner metadata file and aligns the handling of the body with how attachments are handled.

The README has been updated to reflect this new structure.