### PR TITLE
Fix: Use non-deprecated type for message response

### DIFF
--- a/o365client/o365client.go
+++ b/o365client/o365client.go
@@ -54,7 +54,7 @@ func (c *O365Client) GetMessages(ctx context.Context, mailboxName, sourceFolderI
 	defer close(messagesChan)
 
 	var (
-		messagesResponse users.ItemMailFoldersItemMessagesDeltaResponseable
+		messagesResponse users.ItemMailFoldersItemMessagesDeltaGetResponseable
 		err              error
 	)
 


### PR DESCRIPTION
Replaced the deprecated `users.ItemMailFoldersItemMessagesDeltaResponseable` with the recommended `users.ItemMailFoldersItemMessagesDeltaGetResponseable` in `o365client/o365client.go`.

This resolves the SA1019 staticcheck linter warning.